### PR TITLE
[1.x] Handle items included in arrays in toArray conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,16 +88,30 @@ class DummyData extends AbstractData
     public string $firstName;
 
     public DummyData $childData;
+    
+     /** @var self[] */
+    public array $children = [];
 }
 
 $data = new DummyData([
     'firstName' => 'Roman',
     'childData' => new DummyData([
         'firstName' => 'Tim',
-    ])
+    ]),
+    'children' => [
+        new DummyData([
+            'firstName' => 'Tom'
+        ]),
+    ],
 ]);
 
-$data->toArray(); // ['firstName' => 'Roman', 'childData' => ['firstName' => 'Tim']];
+$data->toArray();
+
+// [
+//    'firstName' => 'Roman',
+//    'childData' => ['firstName' => 'Tim']
+//    'children' => [ ['firstName' => 'Tom'] ] 
+// ];
 ```
 
 #### Convert keys

--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ $data->toArray();
 // [
 //    'firstName' => 'Roman',
 //    'childData' => ['firstName' => 'Tim']
-//    'children' => [ ['firstName' => 'Tom'] ] 
+//    'children' => [
+//        ['firstName' => 'Tom']
+//    ] 
 // ];
 ```
 

--- a/src/AbstractData.php
+++ b/src/AbstractData.php
@@ -216,7 +216,7 @@ abstract class AbstractData implements JsonSerializable
      */
     private function walkValuesDataCallback(Closure $callback): array
     {
-        return array_map(static function ($value) use ($callback) {
+        $serializeItem = static function ($value, Closure $callback) {
             if ($value instanceof self) {
                 return $callback($value);
             }
@@ -225,15 +225,17 @@ abstract class AbstractData implements JsonSerializable
                 return $value->jsonSerialize();
             }
 
+            return $value;
+        };
+
+        return array_map(static function ($value) use ($callback, $serializeItem) {
             if (is_array($value)) {
                 foreach ($value as $key => $item) {
-                    if ($item instanceof JsonSerializable) {
-                        $value[$key] = $item->jsonSerialize();
-                    }
+                    $value[$key] = $serializeItem($item, $callback);
                 }
             }
 
-            return $value;
+            return $serializeItem($value, $callback);
         }, $this->getValues());
     }
 }

--- a/src/AbstractData.php
+++ b/src/AbstractData.php
@@ -225,6 +225,14 @@ abstract class AbstractData implements JsonSerializable
                 return $value->jsonSerialize();
             }
 
+            if (is_array($value)) {
+                foreach ($value as $key => $item) {
+                    if ($item instanceof JsonSerializable) {
+                        $value[$key] = $item->jsonSerialize();
+                    }
+                }
+            }
+
             return $value;
         }, $this->getValues());
     }

--- a/tests/ToArrayTest.php
+++ b/tests/ToArrayTest.php
@@ -39,6 +39,30 @@ class ToArrayTest extends TestCase
         ], $data->toArray());
     }
 
+    public function testToArrayNestedObjectsInArray()
+    {
+        $data = new class(['children' => [new class(['text' => 'foo']) extends AbstractData {
+            public string $text;
+        }]]) extends AbstractData {
+            public array $children = [];
+        };
+
+        self::assertSame(['children' => [['text' => 'foo']]], $data->toArray());
+    }
+
+    public function testToArrayNestedObjectsInArrayDeep()
+    {
+        $data = new class(['children' => [new class(['children' => [new class(['text' => 'foo']) extends AbstractData {
+            public string $text;
+        }]]) extends AbstractData {
+            public array $children = [];
+        }]]) extends AbstractData {
+            public array $children = [];
+        };
+
+        self::assertSame(['children' => [['children' => [['text' => 'foo']]]]], $data->toArray());
+    }
+
     public function testFilteredStaticProperties()
     {
         $data = new class([]) extends AbstractData {

--- a/tests/ToArrayTest.php
+++ b/tests/ToArrayTest.php
@@ -63,6 +63,19 @@ class ToArrayTest extends TestCase
         self::assertSame(['children' => [['children' => [['text' => 'foo']]]]], $data->toArray());
     }
 
+    public function testToArrayNestedObjectsInArrayDeepConvertedKeyCase()
+    {
+        $data = new class(['more_children' => [new class(['someChildren' => [new class(['text' => 'foo']) extends AbstractData {
+            public string $text;
+        }]]) extends AbstractData {
+            public array $someChildren = [];
+        }]]) extends AbstractData {
+            public array $more_children = [];
+        };
+
+        self::assertSame(['more_children' => [['some_children' => [['text' => 'foo']]]]], $data->toArrayConverted(SnakeCase::class));
+    }
+
     public function testFilteredStaticProperties()
     {
         $data = new class([]) extends AbstractData {


### PR DESCRIPTION
```php
use romanzipp\DTO\AbstractData;

class DummyData extends AbstractData
{
    public string $text;

    /** @var self[] */
    public array $children = [];
}

$data = new DummyData([
    'children' => [
        new DummyData([
            'text' => 'foo',
        ]),
    ],
]);

return $data->toArray();
```

## Before

```
array:1 [
  "children" => array:1 [
    0 => DummyData^ {#372
      +text: "foo"
    }
  ]
]
```

## After

```
array:1 [
  "children" => array:1 [
    0 => array:1 [
      "text" => "foo"
    ]
  ]
]
```